### PR TITLE
Support more GHCs on hackage

### DIFF
--- a/partial-semigroup-test/package.yaml
+++ b/partial-semigroup-test/package.yaml
@@ -27,6 +27,6 @@ library:
     - Test.PartialSemigroup
 
 dependencies:
-  - base >= 4.9 && < 4.10
+  - base >= 4.8 && < 4.11
   - hedgehog >= 0.5 && < 0.6
   - partial-semigroup

--- a/partial-semigroup/package.yaml
+++ b/partial-semigroup/package.yaml
@@ -27,7 +27,8 @@ library:
     - Data.PartialSemigroup
 
 dependencies:
-  - base >= 4.9 && < 4.10
+  - base >= 4 && < 4.11
+  - semigroups >= 0.8.4 && < 1
 
 tests:
 

--- a/partial-semigroup/src/Data/PartialSemigroup.hs
+++ b/partial-semigroup/src/Data/PartialSemigroup.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase          #-}
-
 module Data.PartialSemigroup
   (
   -- * Partial semigroup
@@ -184,8 +182,8 @@ the semigroup operation is defined over them. -}
 -- [Left "a",Right "bc",Left "def"]
 
 groupAndConcat :: PartialSemigroup a => [a] -> [a]
-groupAndConcat =
-  \case
+groupAndConcat as =
+  case as of
     []         -> []
     [x]        -> [x]
     x : y : zs -> case x <>? y of
@@ -232,8 +230,8 @@ partialConcat x =
 -- Nothing
 
 partialConcat1 :: PartialSemigroup a => NonEmpty a -> Maybe a
-partialConcat1 =
-  \case
+partialConcat1 as =
+  case as of
     x :| [] -> Just x
     x :| (y : zs) ->
       do


### PR DESCRIPTION
This PR makes the library work as far back as GHC 7.4 (although the tests won't build that far back) and as far forward as 8.2.1. I think this is a big win for little effort.

I think partial-semigroup 0.0.0.1 and 0.1.0.1 could be given [hackage metadata revisions](http://hackage.haskell.org/package/tasty-hedgehog) to make them work with more versions, although because of the use of LambdaCase, they will only work as far back as GHC 7.6
If you are interested in making these metadata revisions, the bound would be `base >= 4.6 && < 4.11`

[partial-semigroup-test](https://matrix.hackage.haskell.org/package/partial-semigroup-test#GHC-8.0/partial-semigroup-test-0.0.0.1) 0.0.0.1 does not build at all, so please make a metadata revision to make its bounds unsatisfiable (`base > 100 && < 100`)
I think partial-semigroup-test 0.1.0.1 would work with `base >= 4.8 && < 4.11`