### PR TITLE
Bump base bounds for GHC 8.6.1

### DIFF
--- a/partial-semigroup-hedgehog/partial-semigroup-hedgehog.cabal
+++ b/partial-semigroup-hedgehog/partial-semigroup-hedgehog.cabal
@@ -30,6 +30,6 @@ library
   exposed-modules: Test.PartialSemigroup.Hedgehog
 
   build-depends:
-      base >=4 && <4.12
+      base >=4 && <4.13
     , hedgehog >=0.5 && <0.7
-    , partial-semigroup >=0.2 && <0.4
+    , partial-semigroup >=0.2 && <0.5

--- a/partial-semigroup/partial-semigroup.cabal
+++ b/partial-semigroup/partial-semigroup.cabal
@@ -60,7 +60,7 @@ flag enable-doctest
 library
   ghc-options: -Wall
   default-language: Haskell2010
-  build-depends: base >=4 && <4.12
+  build-depends: base >=4 && <4.13
   hs-source-dirs: src
 
   exposed-modules: Data.PartialSemigroup
@@ -84,7 +84,7 @@ test-suite docs
   default-language: Haskell2010
   hs-source-dirs: test
   main-is: docs.hs
-  build-depends: base >=4 && <4.12
+  build-depends: base >=4 && <4.13
 
   if flag(enable-doctest)
     build-depends: doctest >=0.11 && <0.17
@@ -98,7 +98,7 @@ test-suite examples
   main-is: examples.hs
 
   build-depends:
-      base >=4 && <4.12
+      base >=4 && <4.13
     , partial-semigroup
 
   if flag(enable-hedgehog)
@@ -117,7 +117,7 @@ test-suite properties
   hs-source-dirs: test
   main-is: properties.hs
   build-depends:
-      base >=4 && <4.12
+      base >=4 && <4.13
     , partial-semigroup
 
   if flag(enable-hedgehog)
@@ -138,7 +138,7 @@ test-suite generics
   hs-source-dirs: test
   main-is: generics.hs
   build-depends:
-      base >=4 && <4.12
+      base >=4 && <4.13
     , partial-semigroup
 
   if flag(generics-in-base)


### PR DESCRIPTION
I've also made a metadata revision to partial-semigroup 0.3.0.1 since it was causing bad install plans on GHC 8.4 and 8.6