### PR TITLE
Add `PartialMonoid` typeclass

### DIFF
--- a/partial-semigroup/test/Test/PartialSemigroup/Hedgehog.hs
+++ b/partial-semigroup/test/Test/PartialSemigroup/Hedgehog.hs
@@ -2,10 +2,11 @@
 -- testing library.
 module Test.PartialSemigroup.Hedgehog
   ( assoc,
+    identity,
   )
 where
 
-import Data.PartialSemigroup (PartialSemigroup (..))
+import Data.PartialSemigroup (PartialMonoid (..), PartialSemigroup (..))
 import Hedgehog (Gen, Property, forAll, property, (===))
 
 -- | The partial semigroup associativity axiom:
@@ -24,3 +25,20 @@ assoc gen = property $ do
       yz <- y <>? z
 
       return (x <>? yz === xy <>? z)
+
+-- | The partial monoid identity axiom:
+--
+-- For all @x@, @y@: @'pmempty' '<>?' x = x '<>?' 'pmempty'@ and if @'pmempty
+-- '<>?' x = 'Just' y@, @x = y@.
+identity :: (PartialMonoid a, Eq a, Show a) => Gen a -> Property
+identity gen = property $ do
+  x <- forAll gen
+
+  -- Both are either Nothing or Just y.
+  pmempty <>? x === x <>? pmempty
+
+  -- If they are Just y, then y == x.
+  sequence_ $
+    do
+      oneX <- pmempty <>? x
+      return (oneX === x)

--- a/partial-semigroup/test/properties.hs
+++ b/partial-semigroup/test/properties.hs
@@ -16,7 +16,7 @@ import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 import System.Exit qualified as Exit
 import System.IO qualified as IO
-import Test.PartialSemigroup.Hedgehog (assoc)
+import Test.PartialSemigroup.Hedgehog (assoc, identity)
 
 main :: IO ()
 main = do
@@ -34,17 +34,33 @@ prop_unit_assoc :: Property
 prop_unit_assoc =
   assoc (Gen.constant ())
 
+prop_unit_identity :: Property
+prop_unit_identity =
+  identity (Gen.constant ())
+
 prop_identity_assoc :: Property
 prop_identity_assoc =
   assoc (Identity <$> genStr)
+
+prop_identity_identity :: Property
+prop_identity_identity =
+  identity (Identity <$> genStr)
 
 prop_list_assoc :: Property
 prop_list_assoc =
   assoc genStr
 
+prop_list_identity :: Property
+prop_list_identity =
+  identity genStr
+
 prop_list_total_assoc :: Property
 prop_list_total_assoc =
   assoc (Total <$> genStr)
+
+prop_list_total_identity :: Property
+prop_list_total_identity =
+  identity (Total <$> genStr)
 
 prop_zipList_assoc :: Property
 prop_zipList_assoc =
@@ -58,25 +74,46 @@ prop_tuple2_assoc :: Property
 prop_tuple2_assoc =
   assoc ((,) <$> genStr <*> genEither)
 
+prop_tuple2_identity :: Property
+prop_tuple2_identity =
+  identity ((,) <$> genStr <*> Gen.constant ())
+
 prop_tuple3_assoc :: Property
 prop_tuple3_assoc =
   assoc ((,,) <$> genStr <*> genEither <*> genSum)
+
+prop_tuple3_identity :: Property
+prop_tuple3_identity =
+  identity ((,,) <$> genStr <*> Gen.constant () <*> genSum)
 
 prop_appendLeft_assoc :: Property
 prop_appendLeft_assoc =
   assoc (AppendLeft <$> genEither)
 
+prop_appendLeft_identity :: Property
+prop_appendLeft_identity =
+  identity (AppendLeft <$> genEither)
+
 prop_appendRight_assoc :: Property
 prop_appendRight_assoc =
   assoc (AppendRight <$> genEither)
+
+prop_appendRight_identity :: Property
+prop_appendRight_identity =
+  identity (AppendRight <$> genEither)
 
 prop_one_assoc :: Property
 prop_one_assoc =
   assoc (One <$> genMaybe)
 
+
 prop_atMostOne_assoc :: Property
 prop_atMostOne_assoc =
   assoc (AtMostOne <$> genMaybe)
+
+prop_atMostOne_identity :: Property
+prop_atMostOne_identity =
+  identity (AtMostOne <$> genMaybe)
 
 --------------------------------------------------------------------------------
 --  Generators


### PR DESCRIPTION
It is sometimes useful to consider partial semigroups that also have an identity element, say `pmempty`.  Many, but not all, partial semigroups that have instances in this library are also partial monoids, with some identity element.  This patch introduces a typeclass, `PartialMonoid`, that represents such types.  This typeclass is meant to directly mirror the standard `Monoid` typeclass, prepending `pm` to each function in the standard typeclass and changing their types to represent partiality.  The only deviation here is removing `pmappend` from the typeclass, since this is necessarily an alias for `<>?` specialized to monoids; unlike with the standard `mappend`, by moving this out of the typeclass, we avoid any possibility of unlawful instances where `pmappend ≢ (<>?)`.

This patch tags each addition with a `@since 0.7.0.0` Haddock annotation, on the assumption that these changes will be included in a new release of the library with that version.

Fixes #13.